### PR TITLE
Add MangAdventure extensions

### DIFF
--- a/libs/core/src/extensions/arcrelight/index.ts
+++ b/libs/core/src/extensions/arcrelight/index.ts
@@ -1,0 +1,83 @@
+import {
+  type GetSeriesFunc,
+  type GetChaptersFunc,
+  type GetPageRequesterDataFunc,
+  type GetPageUrlsFunc,
+  type GetFilterOptionsFunc,
+  type GetSearchFunc,
+  type GetImageFunc,
+  type GetDirectoryFunc,
+  type Series,
+  type PageRequesterData,
+  type SetSettingsFunc,
+  type GetSettingsFunc,
+  type GetSettingTypesFunc,
+  type FilterValues,
+  type WebviewFunc,
+  ExtensionClientAbstract,
+} from '@tiyo/common';
+import { METADATA } from './metadata';
+import { MangAdventureClient } from '../../generic/mangadventure';
+
+export * from './metadata';
+
+const CATEGORIES: string[] = [
+  '4-koma',
+  'Chaos;Head',
+  'Collection',
+  'Comedy',
+  'Drama',
+  'Jubilee',
+  'Mystery',
+  'Psychological',
+  'Robotics;Notes',
+  'Romance',
+  'Sci-Fi',
+  'Seinen',
+  'Shounen',
+  'Steins;Gate',
+  'Supernatural',
+  'Tragedy',
+];
+
+export class ExtensionClient extends ExtensionClientAbstract {
+  mangAdventureClient: MangAdventureClient;
+
+  constructor(webviewFn: WebviewFunc) {
+    super(webviewFn);
+    this.mangAdventureClient = new MangAdventureClient(METADATA.id, METADATA.url, CATEGORIES);
+  }
+
+  override getSeries: GetSeriesFunc = (id) =>
+    this.mangAdventureClient.getSeries(id);
+
+  override getChapters: GetChaptersFunc = (id) =>
+    this.mangAdventureClient.getChapters(id);
+
+  override getPageRequesterData: GetPageRequesterDataFunc = (_, chapterSourceId) =>
+    this.mangAdventureClient.getPageRequesterData(_, chapterSourceId);
+
+  override getPageUrls: GetPageUrlsFunc = (pageRequesterData) =>
+    this.mangAdventureClient.getPageUrls(pageRequesterData);
+
+  override getImage: GetImageFunc = (series, url) =>
+    this.mangAdventureClient.getImage(series, url);
+
+  override getSearch: GetSearchFunc = (text, page, filterValues) =>
+    this.mangAdventureClient.getSearch(text, page, filterValues);
+
+  override getDirectory: GetDirectoryFunc = (page, filterValues) =>
+    this.mangAdventureClient.getDirectory(page, filterValues);
+
+  override getFilterOptions: GetFilterOptionsFunc = () =>
+    this.mangAdventureClient.getFilterOptions();
+
+  override getSettingTypes: GetSettingTypesFunc = () =>
+    this.mangAdventureClient.getSettingTypes();
+
+  override getSettings: GetSettingsFunc = () =>
+    this.mangAdventureClient.getSettings();
+
+  override setSettings: SetSettingsFunc = (newSettings) =>
+    this.mangAdventureClient.setSettings(newSettings);
+}

--- a/libs/core/src/extensions/arcrelight/metadata.ts
+++ b/libs/core/src/extensions/arcrelight/metadata.ts
@@ -1,0 +1,8 @@
+import { type ExtensionMetadata, LanguageKey } from '@tiyo/common';
+
+export const METADATA: ExtensionMetadata = {
+  id: '6b1ecf7f-3a39-4959-a009-17aaa925c95f',
+  name: 'Arc-Relight',
+  url: 'https://arc-relight.com',
+  translatedLanguage: LanguageKey.ENGLISH,
+};

--- a/libs/core/src/extensions/assortedscans/index.ts
+++ b/libs/core/src/extensions/assortedscans/index.ts
@@ -1,0 +1,64 @@
+import {
+  type GetSeriesFunc,
+  type GetChaptersFunc,
+  type GetPageRequesterDataFunc,
+  type GetPageUrlsFunc,
+  type GetFilterOptionsFunc,
+  type GetSearchFunc,
+  type GetImageFunc,
+  type GetDirectoryFunc,
+  type Series,
+  type PageRequesterData,
+  type SetSettingsFunc,
+  type GetSettingsFunc,
+  type GetSettingTypesFunc,
+  type FilterValues,
+  type WebviewFunc,
+  ExtensionClientAbstract,
+} from '@tiyo/common';
+import { METADATA } from './metadata';
+import { MangAdventureClient } from '../../generic/mangadventure';
+
+export * from './metadata';
+
+export class ExtensionClient extends ExtensionClientAbstract {
+  mangAdventureClient: MangAdventureClient;
+
+  constructor(webviewFn: WebviewFunc) {
+    super(webviewFn);
+    this.mangAdventureClient = new MangAdventureClient(METADATA.id, METADATA.url);
+  }
+
+  override getSeries: GetSeriesFunc = (id) =>
+    this.mangAdventureClient.getSeries(id);
+
+  override getChapters: GetChaptersFunc = (id) =>
+    this.mangAdventureClient.getChapters(id);
+
+  override getPageRequesterData: GetPageRequesterDataFunc = (_, chapterSourceId) =>
+    this.mangAdventureClient.getPageRequesterData(_, chapterSourceId);
+
+  override getPageUrls: GetPageUrlsFunc = (pageRequesterData) =>
+    this.mangAdventureClient.getPageUrls(pageRequesterData);
+
+  override getImage: GetImageFunc = (series, url) =>
+    this.mangAdventureClient.getImage(series, url);
+
+  override getSearch: GetSearchFunc = (text, page, filterValues) =>
+    this.mangAdventureClient.getSearch(text, page, filterValues);
+
+  override getDirectory: GetDirectoryFunc = (page, filterValues) =>
+    this.mangAdventureClient.getDirectory(page, filterValues);
+
+  override getFilterOptions: GetFilterOptionsFunc = () =>
+    this.mangAdventureClient.getFilterOptions();
+
+  override getSettingTypes: GetSettingTypesFunc = () =>
+    this.mangAdventureClient.getSettingTypes();
+
+  override getSettings: GetSettingsFunc = () =>
+    this.mangAdventureClient.getSettings();
+
+  override setSettings: SetSettingsFunc = (newSettings) =>
+    this.mangAdventureClient.setSettings(newSettings);
+}

--- a/libs/core/src/extensions/assortedscans/metadata.ts
+++ b/libs/core/src/extensions/assortedscans/metadata.ts
@@ -1,0 +1,8 @@
+import { type ExtensionMetadata, LanguageKey } from '@tiyo/common';
+
+export const METADATA: ExtensionMetadata = {
+  id: '8332d4fe-f1da-4820-b375-e0fe10a8260a',
+  name: 'Assorted Scans',
+  url: 'https://assortedscans.com',
+  translatedLanguage: LanguageKey.ENGLISH,
+};

--- a/libs/core/src/generic/mangadventure/filters.ts
+++ b/libs/core/src/generic/mangadventure/filters.ts
@@ -1,0 +1,62 @@
+export enum FilterControlIds {
+  Sort = 'sort',
+  Author = 'author',
+  Artist = 'artist',
+  Status = 'status',
+  Categories = 'categories',
+}
+
+export const SORT_FIELDS: {
+  key: string, label: string
+}[] = [
+  { key: 'title', label: 'Title' },
+  { key: 'views', label: 'Views' },
+  { key: 'latest_upload', label: 'Latest Upload' },
+  { key: 'chapter_count', label: 'Chapter Count' },
+];
+
+export const STATUS_OPTIONS: {
+  value: string, label: string
+}[] = [
+  { value: 'any', label: 'Any' },
+  { value: 'ongoing', label: 'Ongoing' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'hiatus', label: 'Hiatus' },
+  { value: 'canceled', label: 'Canceled' },
+];
+
+export const DEFAULT_CATEGORIES: string[] = [
+ '4-Koma',
+ 'Action',
+ 'Adventure',
+ 'Comedy',
+ 'Doujinshi',
+ 'Drama',
+ 'Ecchi',
+ 'Fantasy',
+ 'Gender Bender',
+ 'Harem',
+ 'Hentai',
+ 'Historical',
+ 'Horror',
+ 'Josei',
+ 'Martial Arts',
+ 'Mecha',
+ 'Mystery',
+ 'Psychological',
+ 'Romance',
+ 'School Life',
+ 'Sci-Fi',
+ 'Seinen',
+ 'Shoujo',
+ 'Shoujo Ai',
+ 'Shounen',
+ 'Shounen Ai',
+ 'Slice of Life',
+ 'Smut',
+ 'Sports',
+ 'Supernatural',
+ 'Tragedy',
+ 'Yaoi',
+ 'Yuri',
+];

--- a/libs/core/src/generic/mangadventure/index.ts
+++ b/libs/core/src/generic/mangadventure/index.ts
@@ -1,0 +1,220 @@
+import {
+  type GetSeriesFunc,
+  type GetChaptersFunc,
+  type GetPageRequesterDataFunc,
+  type GetPageUrlsFunc,
+  type GetFilterOptionsFunc,
+  type GetSearchFunc,
+  type GetImageFunc,
+  type PageRequesterData,
+  type GetDirectoryFunc,
+  type GetSettingsFunc,
+  type SetSettingsFunc,
+  type GetSettingTypesFunc,
+  type SeriesListResponse,
+  type Chapter,
+  type Series,
+  type FilterValues,
+  SeriesStatus,
+  LanguageKey,
+  FilterSort,
+  SortDirection,
+  TriState,
+  FilterInput,
+  FilterSeparator,
+  FilterSelect,
+  FilterMultiToggle,
+  FilterSortValue,
+  MultiToggleValues,
+} from '@tiyo/common';
+
+import {
+  type APIResults,
+  type APIPaginator,
+  type APICategory,
+  type APIPage,
+  type APIChapter,
+  type APISeriesBase,
+  type APISeries,
+} from './types';
+
+import {
+  SORT_FIELDS,
+  STATUS_OPTIONS,
+  DEFAULT_CATEGORIES,
+  FilterControlIds
+} from './filters';
+
+function _getStatus(status: APISeries['status']): SeriesStatus {
+  switch (status) {
+    case 'ongoing':
+    case 'hiatus':
+      return SeriesStatus.ONGOING;
+    case 'completed':
+      return SeriesStatus.COMPLETED;
+    case 'canceled':
+      return SeriesStatus.CANCELLED;
+  }
+}
+
+export class MangAdventureClient {
+  extensionId: string;
+  baseUrl: string;
+  categories: string[];
+
+  constructor(extensionId: string, baseUrl: string, categories?: string[]) {
+    this.extensionId = extensionId;
+    this.baseUrl = baseUrl;
+    this.categories = categories ?? DEFAULT_CATEGORIES;
+  }
+
+  get _platform(): string {
+    switch (process.platform) {
+      case 'win32':
+      case 'cygwin':
+        return 'Windows';
+      case 'linux':
+        return 'Linux';
+      case 'darwin':
+        return 'Macintosh';
+      default:
+        return process.platform;
+    }
+  }
+
+  get _userAgent(): string {
+    return `Mozilla/5.0 (${this._platform}) Chrome/${process.versions.chrome} Houdoku`;
+  }
+
+  getSeries: GetSeriesFunc = (id) =>
+    this._fetchAPI<APISeries, Series>(`/series/${id}`, (data) => ({
+      id: undefined,
+      extensionId: this.extensionId,
+      sourceId: data.slug,
+      title: data.title,
+      altTitles: data.aliases,
+      description: data.description,
+      authors: data.authors,
+      artists: data.artists,
+      tags: data.categories,
+      remoteCoverUrl: data.cover,
+      status: _getStatus(data.status),
+      originalLanguageKey: LanguageKey.JAPANESE,
+      numberUnread: 0
+    }));
+
+  getChapters: GetChaptersFunc = (id) =>
+    this._fetchAPI<APIResults<APIChapter>, Chapter[]>(
+      `/series/${id}/chapters?date_format=timestamp`,
+      (data) => data.results.map(value => ({
+        id: undefined,
+        seriesId: undefined,
+        sourceId: value.id.toString(),
+        title: value.full_title,
+        chapterNumber: value.number.toString(),
+        volumeNumber: value.volume?.toString() ?? '',
+        groupName: value.groups.join(', '),
+        time: Number(value.published),
+        languageKey: LanguageKey.ENGLISH,
+        read: false
+      }))
+    );
+
+  getPageRequesterData: GetPageRequesterDataFunc = (_, chapterSourceId) =>
+    this._fetchAPI<APIResults<APIPage>, PageRequesterData>(
+      `/chapters/${chapterSourceId}/pages?track=true`,
+      (data) => ({
+        server: '',
+        hash: '',
+        numPages: data.results.length,
+        pageFilenames: data.results.map(p => p.image)
+      })
+    );
+
+  getDirectory: GetDirectoryFunc = (page, filterValues) =>
+    this.getSearch('', page, filterValues);
+
+  getSearch: GetSearchFunc = (text, page, filterValues) => {
+    const params = new URLSearchParams({page: page.toString()});
+    if (text) params.set('title', text);
+    if (FilterControlIds.Sort in filterValues) {
+      const sort = filterValues[FilterControlIds.Sort] as FilterSortValue;
+      const prefix = sort.direction == SortDirection.DESCENDING ? '-' : '';
+      params.set('sort', prefix + sort.key);
+    }
+    if (FilterControlIds.Author in filterValues) {
+      const author = filterValues[FilterControlIds.Author] as string;
+      if (author) params.set('author', author);
+    }
+    if (FilterControlIds.Artist in filterValues) {
+      const artist = filterValues[FilterControlIds.Artist] as string;
+      if (artist) params.set('artist', artist);
+    }
+    if (FilterControlIds.Status in filterValues) {
+      const status = filterValues[FilterControlIds.Status] as string;
+      params.set('status', status);
+    }
+    if (FilterControlIds.Categories in filterValues) {
+      const values = filterValues[FilterControlIds.Categories] as MultiToggleValues;
+      const categories = Object.entries(values)
+        .filter(([key, value]) => value != TriState.IGNORE)
+        .map(([key, value]) => (value == TriState.EXCLUDE ? '-' : '') + key);
+      if (categories.length > 0) params.set('categories', categories.join(','));
+    }
+    return this._fetchAPI<APIPaginator<APISeriesBase>, SeriesListResponse>(
+      `/series?${params}`, (data) => ({
+        hasMore: !data.last,
+        seriesList: data.results.filter(value => value.chapters).map(value => ({
+          id: undefined,
+          extensionId: this.extensionId,
+          sourceId: value.slug,
+          title: value.title,
+          altTitles: [],
+          description: '',
+          authors: [],
+          artists: [],
+          tags: [],
+          remoteCoverUrl: value.cover,
+          status: SeriesStatus.ONGOING,
+          originalLanguageKey: LanguageKey.JAPANESE,
+          numberUnread: 0
+        }))
+      })
+    );
+  }
+
+  getPageUrls: GetPageUrlsFunc = (pageRequesterData) =>
+    pageRequesterData.pageFilenames;
+
+  getImage: GetImageFunc = (series, url) =>
+    Promise.resolve(url);
+
+  getFilterOptions: GetFilterOptionsFunc = () => [
+    new FilterSort(FilterControlIds.Sort, 'Sort', {
+      key: 'title', direction: SortDirection.ASCENDING
+    }).withFields(SORT_FIELDS)
+      .withSupportsBothDirections(true),
+    new FilterSeparator('separator1', '', ''),
+    new FilterInput(FilterControlIds.Author, 'Author', ''),
+    new FilterInput(FilterControlIds.Artist, 'Artist', ''),
+    new FilterSeparator('separator2', '', ''),
+    new FilterSelect(FilterControlIds.Status, 'Status', 'any')
+      .withOptions(STATUS_OPTIONS),
+    new FilterSeparator('separator3', '', ''),
+    new FilterMultiToggle(FilterControlIds.Categories, 'Categories', {})
+      .withFields(this.categories.map(key => ({ key, label: key })))
+      .withIsTriState(true),
+  ];
+
+  getSettingTypes: GetSettingTypesFunc = () => ({});
+
+  getSettings: GetSettingsFunc = () => ({});
+
+  setSettings: SetSettingsFunc = (newSettings) => {};
+
+  _fetchAPI<T, R>(path: string, transform: (data: T) => R): Promise<R> {
+    const url = new URL('/api/v2' + path, this.baseUrl);
+    const headers = new Headers({ 'User-Agent': this._userAgent });
+    return fetch(url, { headers }).then(res => res.json()).then(transform);
+  }
+}

--- a/libs/core/src/generic/mangadventure/types.ts
+++ b/libs/core/src/generic/mangadventure/types.ts
@@ -1,0 +1,61 @@
+/** Generic results wrapper schema. */
+export type APIResults<T> = {
+  results: T[];
+}
+
+/** Paginator wrapper schema. */
+export type APIPaginator<T> = APIResults<T> & {
+  total: number;
+  last: boolean;
+}
+
+/** Category model schema. */
+export type APICategory = {
+    name: string;
+    description: string;
+}
+
+/** Page model schema. */
+export type APIPage = {
+    id: number;
+    image: string;
+    number: number;
+    url: string;
+}
+
+/** Chapter model schema. */
+export type APIChapter = {
+    id: number;
+    title: string;
+    number: number;
+    volume: number | null;
+    published: string;
+    final: boolean;
+    series: string;
+    groups: string[];
+    full_title: string;
+    url: string;
+}
+
+/** Base series model schema. */
+export type APISeriesBase = {
+    slug: string;
+    title: string;
+    url: string;
+    cover: string;
+    updated: string;
+    chapters?: number | null;
+}
+
+/** Extended series model schema. */
+export type APISeries = APISeriesBase & {
+    views: number;
+    description: string;
+    completed: boolean;
+    licensed: boolean;
+    aliases: string[];
+    authors: string[];
+    artists: string[];
+    categories: string[];
+    status: 'ongoing' | 'completed' | 'hiatus' | 'canceled';
+}

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -1,5 +1,7 @@
 import { TiyoClientAbstract, WebviewFunc } from '@tiyo/common';
 import * as anatanomotokare from './extensions/anatanomotokare';
+import * as arcrelight from './extensions/arcrelight';
+import * as assortedscans from './extensions/assortedscans';
 import * as comick from './extensions/comick';
 import * as deathtollscans from './extensions/deathtollscans';
 import * as disasterscans from './extensions/disasterscans';
@@ -59,6 +61,8 @@ export class TiyoClient extends TiyoClientAbstract {
   // prettier-ignore
   override getExtensions = () => ({
     [anatanomotokare.METADATA.id]: { metadata: anatanomotokare.METADATA, client: new anatanomotokare.ExtensionClient(this._webviewFn)},
+    [arcrelight.METADATA.id]: { metadata: arcrelight.METADATA, client: new arcrelight.ExtensionClient(this._webviewFn)},
+    [assortedscans.METADATA.id]: { metadata: assortedscans.METADATA, client: new assortedscans.ExtensionClient(this._webviewFn)},
     [comick.METADATA.id]: { metadata: comick.METADATA, client: new comick.ExtensionClient(this._webviewFn)},
     [deathtollscans.METADATA.id]: { metadata: deathtollscans.METADATA, client: new deathtollscans.ExtensionClient(this._webviewFn)},
     [disasterscans.METADATA.id]: { metadata: disasterscans.METADATA, client: new disasterscans.ExtensionClient(this._webviewFn)},


### PR DESCRIPTION
This PR adds a generic MangAdventure client and the following extensions:

- Arc-Relight
- Assorted Scans

---

P.S. Kouhai Work is down and WeebReader is unused.