### PR TITLE
Account for TPB chapter numbers in ReadComicOnline

### DIFF
--- a/libs/core/src/extensions/readcomiconline/index.ts
+++ b/libs/core/src/extensions/readcomiconline/index.ts
@@ -145,12 +145,11 @@ export class ExtensionClient extends ExtensionClientAbstract {
           if (title.startsWith('Issue #')) {
             chapterNum = title.split('Issue #')[1];
           } else {
-            const tpbRegex = /TPB (\d+)\s?(\(Part (\d+)\))?/i;
+            const tpbRegex = /TPB (\d+)/i;
             const match: RegExpMatchArray | null = title.match(tpbRegex);
             if (match !== null) {
               const tpb = match[1];
-              const tpbPart = match[3];
-              chapterNum = `0.${tpb}${tpbPart || ''}`;
+              chapterNum = `0.${tpb}`;
             }
           }
 

--- a/libs/core/src/extensions/readcomiconline/index.ts
+++ b/libs/core/src/extensions/readcomiconline/index.ts
@@ -141,7 +141,18 @@ export class ExtensionClient extends ExtensionClientAbstract {
         return Array.from(rows).map((row) => {
           const link = row.getElementsByTagName('a')![0];
           const title = link.textContent.trim();
-          const chapterNum = title.startsWith('Issue #') ? title.split('Issue #')[1] : '';
+          let chapterNum = '';
+          if (title.startsWith('Issue #')) {
+            chapterNum = title.split('Issue #')[1];
+          } else {
+            const tpbRegex = /TPB (\d+)\s?(\(Part (\d+)\))?/i;
+            const match: RegExpMatchArray | null = title.match(tpbRegex);
+            if (match !== null) {
+              const tpb = match[1];
+              const tpbPart = match[3];
+              chapterNum = `0.${tpb}${tpbPart || ''}`;
+            }
+          }
 
           return {
             id: undefined,

--- a/libs/core/src/extensions/readcomiconline/index.ts
+++ b/libs/core/src/extensions/readcomiconline/index.ts
@@ -142,14 +142,20 @@ export class ExtensionClient extends ExtensionClientAbstract {
           const link = row.getElementsByTagName('a')![0];
           const title = link.textContent.trim();
           let chapterNum = '';
+          let groupName = '';
+          let volumeNumber = '';
           if (title.startsWith('Issue #')) {
             chapterNum = title.split('Issue #')[1];
+            groupName = 'Issue';
           } else {
-            const tpbRegex = /TPB (\d+)/i;
+            const tpbRegex = /TPB (\d+)\s?(\(Part (\d+)\))?/i;
             const match: RegExpMatchArray | null = title.match(tpbRegex);
             if (match !== null) {
               const tpb = match[1];
-              chapterNum = `0.${tpb}`;
+              const tpbPart = match[3];
+              chapterNum = `${tpb}${tpbPart ? `.${tpbPart}` : ''}`;
+              groupName = 'TPB';
+              volumeNumber = tpb;
             }
           }
 
@@ -159,9 +165,9 @@ export class ExtensionClient extends ExtensionClientAbstract {
             sourceId: link.getAttribute('href')!,
             title: title,
             chapterNumber: chapterNum,
-            volumeNumber: '',
+            volumeNumber: volumeNumber,
             languageKey: LanguageKey.ENGLISH,
-            groupName: '',
+            groupName: groupName,
             time: 0,
             read: false,
           };


### PR DESCRIPTION
Without these chapter numbers, certain functionality breaks in the Houdoku app (e.g. unread chapter count). It's not the best solution but I wasn't sure what else to do. Let me know if there could be a better solution.

I've not been able to test it properly as I weren't sure how to get it loaded into Houdoku (couldn't find any instructions unless I've missed something).